### PR TITLE
Automatically download non-apt dependencies using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.11) # Due to FetchContent requirement
 
 project(
     blue-space

--- a/README.md
+++ b/README.md
@@ -13,17 +13,20 @@ with your distribution favourite package manager.
  * Boost.Log
  * [Google Test](https://github.com/google/googletest)
  * [Google Benchmark](https://github.com/google/benchmark)
- * [CLI11 1.9](https://github.com/CLIUtils/CLI11). Note that this project
-   expects to find the header in `<CLI/CLI.hpp>`.
+ * [CLI11 1.9](https://github.com/CLIUtils/CLI11).
+   You can download the header to a location on your file system and set `CLI11_DIR`.
+   If this is not installed, CMake will download it.
  * [Json Rpc Lean](https://github.com/uskr/jsonrpc-lean). Download the source
    on your file system, then set the `JSONRPCLEAN_INCLUDE_DIR` configuration
    variable to the path to jsonrpc-lean `include/` directory.
+   If this is not installed, CMake will download it.
 
 To build the GPU miner, you need the following additional dependencies.
 
  * [The CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit). Follows for example [this step-by-step tutorial](https://cloud.google.com/compute/docs/gpus/install-drivers-gpu).
- * [CGBN](https://github.com/NVlabs/CGBN). You should download the source
-    to a location on your file system.
+ * [CGBN](https://github.com/NVlabs/CGBN). You can download the source
+    to a location on your file system and set `CGBN_INCLUDE_DIR`,
+    otherwise if this is not installed, CMake will download it for you.
 
 On Ubuntu 21.04 you can install all dependencies with:
 
@@ -51,12 +54,10 @@ Configure `cmake`, run the following from the `blue-space` directory.
         -S . \ # the source location
         -B buildir \ # the build directory
         -DCMAKE_BUILD_TYPE=Release \ # make release
-        -DJSONRPCLEAN_INCLUDE_DIR=/path/to/jsonrpc-lean \ # jsonrpc lean include directory
         -DBUILD_TEST=OFF \ # build tests, requires gtest and benchmark
         -DCUDA_MINER=ON \ # enable cuda miner
         -DCUDA_HOST_COMPILER=/usr/bin/g++-10 \ # only needed if you have g++ 11 on your system
         -DCMAKE_CUDA_ARCHITECTURES=35 \ # cuda architecture, depends on your gpu
-        -DCGBN_INCLUDE_DIR=/path/to/cgbn/include # location of your cgbn installation
 
 Finally, build `blue-space`.
 

--- a/blue-space/CMakeLists.txt
+++ b/blue-space/CMakeLists.txt
@@ -1,5 +1,31 @@
 find_package(Boost REQUIRED)
-find_package(JsonRpcLean REQUIRED)
+find_package(JsonRpcLean)
+
+if(NOT JSON_RPC_LEAN_FOUND)
+    message("Downloading JsonRpcLean from GitHub")
+    include(FetchContent)
+    FetchContent_Declare(
+      JsonRpcLean
+      GIT_REPOSITORY https://github.com/uskr/jsonrpc-lean.git
+      GIT_TAG        e23500425fce7d3752e030ae0eeff71e974edd73 # v1.1.0
+    )
+    FetchContent_MakeAvailable(JsonRpcLean)
+    set(JSONRPCLEAN_INCLUDE_DIR "${jsonrpclean_SOURCE_DIR}/include")
+    find_package(JsonRpcLean REQUIRED)
+endif()
+
+# find_package CONFIG will make the CLI11:CLI11 target available if it succeeds
+find_package(CLI11 1.9 CONFIG)
+if(NOT CLI11_FOUND)
+    message("Downloading CLI11 from GitHub")
+    include(FetchContent)
+    FetchContent_Declare(CLI11_EXTERNAL
+        GIT_REPOSITORY    https://github.com/CLIUtils/CLI11.git
+        GIT_TAG           5cb3efabce007c3a0230e4cc2e27da491c646b6c # v1.9.1
+    )
+    # FetchContent will automatically make the CLI11:CLI11 target available
+    FetchContent_MakeAvailable(CLI11_EXTERNAL)
+endif()
 
 set(
     LIB_CPP_SOURCE
@@ -27,6 +53,6 @@ set(
     "src/main.cc"
 )
 add_executable(blue-space ${EXE_CPP_SOURCE})
-target_link_libraries(blue-space PUBLIC application)
+target_link_libraries(blue-space PUBLIC application CLI11::CLI11)
 
 install(TARGETS blue-space RUNTIME DESTINATION bin)

--- a/blue-space/CMakeLists.txt
+++ b/blue-space/CMakeLists.txt
@@ -6,11 +6,11 @@ if(NOT JSON_RPC_LEAN_FOUND)
     include(FetchContent)
     FetchContent_Declare(
       JsonRpcLean
-      GIT_REPOSITORY https://github.com/uskr/jsonrpc-lean.git
-      GIT_TAG        e23500425fce7d3752e030ae0eeff71e974edd73 # v1.1.0
+      URL https://github.com/uskr/jsonrpc-lean/releases/download/1.1.0/jsonrpc-lean-1.1.0.zip
+      URL_HASH SHA3_256=90f74e1999ec3f512ac567b05c48dd386e40d278205f505f3ab0955bbcba326a # v1.1.0
     )
     FetchContent_MakeAvailable(JsonRpcLean)
-    set(JSONRPCLEAN_INCLUDE_DIR "${jsonrpclean_SOURCE_DIR}/include")
+    set(JSONRPCLEAN_INCLUDE_DIR "${jsonrpclean_SOURCE_DIR}")
     find_package(JsonRpcLean REQUIRED)
 endif()
 
@@ -20,8 +20,8 @@ if(NOT CLI11_FOUND)
     message("Downloading CLI11 from GitHub")
     include(FetchContent)
     FetchContent_Declare(CLI11_EXTERNAL
-        GIT_REPOSITORY    https://github.com/CLIUtils/CLI11.git
-        GIT_TAG           5cb3efabce007c3a0230e4cc2e27da491c646b6c # v1.9.1
+        URL https://github.com/CLIUtils/CLI11/archive/refs/tags/v1.9.1.tar.gz
+        URL_HASH SHA3_256=abdbf30c5ec8bf1f72c1bac1a3f24fe55b894bf46c6486acf6fcb5ff6911b8a2 # v1.9.1
     )
     # FetchContent will automatically make the CLI11:CLI11 target available
     FetchContent_MakeAvailable(CLI11_EXTERNAL)

--- a/miner-cuda/CMakeLists.txt
+++ b/miner-cuda/CMakeLists.txt
@@ -10,7 +10,20 @@ set(CUDA_LIBRARIES PUBLIC ${CUDA_LIBRARIES})
 
 set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-use_fast_math)
 
-find_package(CGBN REQUIRED)
+find_package(CGBN)
+
+if(NOT CGBN_FOUND)
+    message("Downloading CGBN from GitHub")
+    include(FetchContent)
+    FetchContent_Declare(CGBN
+        GIT_REPOSITORY    https://github.com/NVlabs/CGBN.git
+        GIT_TAG           2245cc145797d3405cb7d45ec1dec6acca8a7328 # master as of july 16th 2021
+    )
+    FetchContent_MakeAvailable(CGBN)
+    set(CGBN_INCLUDE_DIR "${cgbn_SOURCE_DIR}/include")
+    find_package(CGBN REQUIRED)
+endif(NOT CGBN_FOUND)
+
 find_package(Boost REQUIRED COMPONENTS log)
 
 cuda_add_library(miner-cuda STATIC ${CU_SOURCE})

--- a/miner-cuda/CMakeLists.txt
+++ b/miner-cuda/CMakeLists.txt
@@ -16,8 +16,9 @@ if(NOT CGBN_FOUND)
     message("Downloading CGBN from GitHub")
     include(FetchContent)
     FetchContent_Declare(CGBN
-        GIT_REPOSITORY    https://github.com/NVlabs/CGBN.git
-        GIT_TAG           2245cc145797d3405cb7d45ec1dec6acca8a7328 # master as of july 16th 2021
+        # master commit as of july 16th 2021
+        URL https://github.com/NVlabs/CGBN/tarball/2245cc145797d3405cb7d45ec1dec6acca8a7328
+        URL_HASH SHA3_256=4365e3dea88f381abe1ef0f075fe2fdabe5a07ae21dd1de63bf42467c50d9e98
     )
     FetchContent_MakeAvailable(CGBN)
     set(CGBN_INCLUDE_DIR "${cgbn_SOURCE_DIR}/include")


### PR DESCRIPTION
First of all, thank you for making this miner open-source! This made mining in the current round an absolute breeze!

I was getting a bit annoyed at manually downloading CLI11, Json Rpc Lean, and CGBN on multiple computers, especially when everything else was an easy `sudo apt install` away.

So I used CMake's [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) module to automatically download these libraries, if they couldn't be found.

There is a breaking change. Since FetchContent was only added to CMake in v3.11, I had to bump the cmake minimum version to v3.11. However, I don't think this is too big of a deal, since the `CMAKE_CUDA_ARCHITECTURES` flag in the README is only supported in CMake v3.18 anyway.

This is what my CMake output looks like (I've added `Downloading ... from GitHub` messages for when we download dependencies).

```console
me@computer:~/blue-space$ cmake -B builddir -S . -DBUILD_TEST=OFF -DBUILD_BENCHMARK=OFF -DCUDA_MINER=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=86
-- The CXX compiler identification is GNU 9.3.0
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.1") 
-- Checking for module 'gmpxx'
--   Found gmpxx, version 6.2.0
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake (found version "1.71.0") found components: log 
-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5")  
-- Found Threads: TRUE  
-- Found CUDA: /usr/local/cuda (found version "11.3") 
-- Could NOT find CGBN (missing: CGBN_INCLUDE_DIR) 
Downloading CGBN from GitHub
-- Found CGBN: /home/me/blue-space/builddir/_deps/cgbn-src/include  
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake (found version "1.71.0")  
-- Could NOT find JsonRpcLean (missing: JSONRPCLEAN_INCLUDE_DIR) 
Downloading JsonRpcLean from GitHub
-- Found JsonRpcLean: /home/me/blue-space/builddir/_deps/jsonrpclean-src  
-- Could NOT find CLI11 (missing: CLI11_DIR)
Downloading CLI11 from GitHub
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Doxygen not found, building docs has been disabled
CMake Warning at /usr/share/cmake-3.16/Modules/CPack.cmake:372 (message):
  CPack.cmake has already been included!!
Call Stack (most recent call first):
  builddir/_deps/cli11_external-src/CMakeLists.txt:321 (include)


-- Configuring done
-- Generating done
```